### PR TITLE
Update interface for exact RRT

### DIFF
--- a/examples/planar_hand/planar_hand_rrt_projection.py
+++ b/examples/planar_hand/planar_hand_rrt_projection.py
@@ -31,17 +31,18 @@ joint_limits = {
 
 # %% RRT testing
 params = IrsRrtProjectionParams(q_model_path, joint_limits)
-params.bundle_mode = BundleMode.kFirstAnalytic
+params.bundle_mode = BundleMode.kFirstRandomized
 params.log_barrier_weight_for_bundling = 100
 params.root_node = IrsNode(x0)
 params.max_size = 2000
 params.goal = np.copy(x0)
-params.goal[6] = np.pi
-params.termination_tolerance = 1e-2
+params.goal[2] = np.pi
+params.termination_tolerance = 0.0
 params.goal_as_subgoal_prob = 0.1
+params.regularization = 1e-4
 params.rewire = False
 params.grasp_prob = 0.2
-params.distance_threshold = 50
+params.distance_threshold = np.inf
 params.distance_metric = 'local_u'
 
 # params.distance_metric = 'global'  # If using global metric

--- a/irs_rrt/reachable_set.py
+++ b/irs_rrt/reachable_set.py
@@ -41,7 +41,7 @@ class ReachableSet:
         u = ubar[None, :]
         (x_next, B, is_valid
          ) = self.q_dynamics_p.q_sim_batch.calc_dynamics_parallel(
-            x, u, self.q_dynamics.h, GradientMode.kBOnly, None)
+            x, u, self.q_sim_params)
 
         c = np.array(x_next).squeeze(0)
         B = np.array(B).squeeze(0)
@@ -88,6 +88,7 @@ class ReachableSet:
         Bhat_u = Bhat[self.q_u_indices_into_x, :]
         cov_u = Bhat_u @ Bhat_u.T + self.params.regularization * np.eye(
             self.q_dynamics.dim_x - self.q_dynamics.dim_u)
+
         return cov_u, chat[self.q_u_indices_into_x]
 
     def calc_bundled_dynamics(self, Bhat, chat, du):


### PR DESCRIPTION
1. Fix bug on exact RRT using the previous interface for `q_dynamics_p`. 
2. Update the files to be compatible with the new arrangement of `q_u` and `q_a`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pangtao22/planning_through_contact/53)
<!-- Reviewable:end -->
